### PR TITLE
USER-847: Support French Polynesia Numbers

### DIFF
--- a/iso3166.go
+++ b/iso3166.go
@@ -1422,8 +1422,8 @@ func populateISO3166() {
 	i.Alpha3 = "PYF"
 	i.CountryCode = "689"
 	i.CountryName = "French Polynesia"
-	i.MobileBeginWith = []string{}
-	i.PhoneNumberLengths = []int{6}
+	i.MobileBeginWith = []string{"87", "88", "89"}
+	i.PhoneNumberLengths = []int{6, 8}
 	iso3166Datas = append(iso3166Datas, i)
 
 	i.Alpha2 = "QA"

--- a/phonenumber_test.go
+++ b/phonenumber_test.go
@@ -74,6 +74,7 @@ var mobFormatTests = []struct {
 	{"+86 18 855 512 329", "CN", "8618855512329"},
 	{"+383 4 555 4999", "XK", "38345554999"},
 	{"+224629295237", "GN", "224629295237"},
+	{"+68989657111", "PF", "68989657111"},
 }
 
 func TestFormatMobile(t *testing.T) {
@@ -145,6 +146,7 @@ var mobWithLLFormatTests = []struct {
 	{"+86 (16) 855-512-329", "CN", "8616855512329"},
 	{"+383 4 1234999", "XK", "38341234999"},
 	{"+224629295237", "GN", "224629295237"},
+	{"+68989657111", "PF", "68989657111"},
 }
 
 func TestFormatWithLandLine(t *testing.T) {
@@ -308,6 +310,7 @@ var mobCountryTests = []struct {
 	{"8613855512329", "CN", true},
 	{"38361234999", "XK", true},
 	{"224629295237", "GN", true},
+	{"68989657111", "PF", true},
 }
 
 func TestGetCountryForMobileNumber(t *testing.T) {


### PR DESCRIPTION
French Polynesian numbers are can be 8 digits and start with 87, 88, 89 for mobile phone numbers: https://www.itu.int/dms_pub/itu-t/oth/02/02/T020200004D0003PDFE.pdf